### PR TITLE
add recursor configuration for consul such that it can be used as a r…

### DIFF
--- a/jobs/consul_agent/spec
+++ b/jobs/consul_agent/spec
@@ -63,3 +63,7 @@ properties:
     description: "PEM-encoded client key"
   consul.encrypt_keys:
     description: "A list of passphrases that will be converted into encryption keys, the first key in the list is the active one"
+
+  consul.agent.recursors:
+    description: "addresses of upstream DNS servers that are used to recursively resolve queries if they are not inside the service domain for consul."
+    default: []

--- a/jobs/consul_agent/templates/config.json.erb
+++ b/jobs/consul_agent/templates/config.json.erb
@@ -46,6 +46,7 @@
     "ports" => {
       "dns" => 53,
     },
+    "recursors" => p("consul.agent.recursors"),
 
     # without this, a single bootstrapped server will be orphaned after
     # restarting

--- a/manifest-generation/consul.yml
+++ b/manifest-generation/consul.yml
@@ -81,6 +81,7 @@ properties:
       log_level: (( property_overrides.consul.agent.log_level || nil ))
       servers:
         lan: (( jobs.consul_z1.networks.consul1.static_ips jobs.consul_z2.networks.consul2.static_ips ))
+      recursors: (( property_overrides.consul.agent.recursors || nil ))
 
 # The keys below should not be included in the final stub
 release_version: (( release_version_overrides || "latest" ))


### PR DESCRIPTION
…esolver.

Using this feature would sidestep the resolv.conf failover behavior that sometimes causes delays. 

Not using this feature would not change the default behavior. 

Thanks, 


Jim