### PR TITLE
Do not check the consul server members using IPs

### DIFF
--- a/jobs/consul_agent/templates/agent_ctl.sh.erb
+++ b/jobs/consul_agent/templates/agent_ctl.sh.erb
@@ -139,10 +139,9 @@ EOF
     synced=true
     if [ $expected -gt 0 ]; then
       synced=false
-      consul_server_ips="<%=p("consul.agent.servers.lan").join('\\|')%>"
       for i in $(seq <%= p("consul.agent.sync_timeout_in_seconds") %>); do
         echo "$(date)" "Waiting to have joined one of: ${consul_join}"
-        if $PKG/bin/consul members -status=alive | grep "${consul_server_ips}"; then
+        if $PKG/bin/consul members -status=alive | grep 'server'; then
           synced=true
           break
         fi


### PR DESCRIPTION
Fixes #4 

On some IaaS CPI (like GCE) there is [no support for static
ips](https://github.com/frodenas/bosh-google-cpi/issues/1).

Because that we cannot expect that the variable
`consul.agent.servers.lan` will contain IPs, they can be names like
powerDNS bosh job aliases (`0.consul-z1.cf1.cloudfoundry.microbosh`).

This PR simply checks if the agent joined some server, without
checking if it is any of the IPs in `consul.agent.servers.lan`.

As a drawback, this change won't ensure that the agent join a valid IP in the list, which maybe is a feature we want to keep.