### PR TITLE
add dnsmasq job for better dns handling on vms running a consul agent

### DIFF
--- a/jobs/consul_agent/templates/agent_ctl.sh.erb
+++ b/jobs/consul_agent/templates/agent_ctl.sh.erb
@@ -79,25 +79,6 @@ EOF
     ulimit -v unlimited
     ulimit -n 4096
 
-    # add consul agent's dns to resolv.conf
-    #
-    # /etc/resolv.conf will probably be regenerated all the time, so add the
-    # local dns server to /head, which will be prepended when regenerated.
-    echo 'nameserver 127.0.0.1' > /etc/resolvconf/resolv.conf.d/head
-
-    if resolvconf --updates-are-enabled; then
-      resolvconf -u
-    else
-      # updates are disabled in bosh-lite; in this case just add to
-      # /etc/resolv.conf directly.
-      #
-      # enabling updates and then updating it with resolvconf -u seems to add
-      # dns entries from where the box was generated.
-      if ! grep -q 127.0.0.1 /etc/resolv.conf; then
-        sed -i -e '1i nameserver 127.0.0.1' /etc/resolv.conf
-      fi
-    fi
-
     consul_join="<%=p("consul.agent.servers.lan").join(',')%>"
     server=<%=p("consul.agent.mode") == "server"%>
 

--- a/jobs/consul_agent/templates/config.json.erb
+++ b/jobs/consul_agent/templates/config.json.erb
@@ -44,7 +44,7 @@
     "node_name" => "#{name.gsub('_', '-')}-#{spec.index}",
     "server" => server,
     "ports" => {
-      "dns" => 53,
+      "dns" => 8600,
     },
 
     # without this, a single bootstrapped server will be orphaned after

--- a/jobs/dnsmasq/monit
+++ b/jobs/dnsmasq/monit
@@ -1,0 +1,6 @@
+check process dnsmasq
+  with pidfile /var/vcap/sys/run/dnsmasq/dnsmasq.pid
+  start program "/var/vcap/jobs/dnsmasq/bin/dnsmasq_ctl start" with timeout 60 seconds
+  stop program "/var/vcap/jobs/dnsmasq/bin/dnsmasq_ctl stop"
+  group vcap
+

--- a/jobs/dnsmasq/spec
+++ b/jobs/dnsmasq/spec
@@ -1,0 +1,10 @@
+---
+name: dnsmasq
+templates:
+  dnsmasq_ctl.erb: bin/dnsmasq_ctl
+  dnsmasq.conf.erb: config/dnsmasq.conf
+
+packages:
+  - dnsmasq
+
+properties: {}

--- a/jobs/dnsmasq/templates/dnsmasq.conf.erb
+++ b/jobs/dnsmasq/templates/dnsmasq.conf.erb
@@ -1,0 +1,37 @@
+<%
+
+def discover_dns_servers
+  networks = spec.networks.marshal_dump
+
+  _, network = networks.find do |_name, network_spec|
+    network_spec.default
+  end
+
+  if !network
+    _, network = networks.first
+  end
+
+  dns = network.dns
+
+  dns
+end
+
+nameservers = discover_dns_servers
+
+%>
+domain-needed
+bogus-priv
+strict-order
+port=53
+
+listen-address=127.0.0.1
+interface=lo
+bind-interfaces
+expand-hosts
+cache-size=1000
+all-servers
+
+server=/cf.internal/127.0.0.1#8600
+<% nameservers.each do |ns| %>
+server=<%= ns %>
+<% end %>

--- a/jobs/dnsmasq/templates/dnsmasq_ctl.erb
+++ b/jobs/dnsmasq/templates/dnsmasq_ctl.erb
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+LOG_DIR=/var/vcap/sys/log/dnsmasq
+RUN_DIR=/var/vcap/sys/run/dnsmasq
+DATA_DIR=/var/vcap/store/dnsmasq
+CONF_DIR=/var/vcap/jobs/dnsmasq/config
+
+PKG=/var/vcap/packages/dnsmasq
+
+PID_FILE=$RUN_DIR/dnsmasq.pid
+
+source /var/vcap/packages/consul-common/utils.sh
+
+case $1 in
+  start)
+
+    pid_guard ${PID_FILE} "dnsmasq"
+
+    mkdir -p $LOG_DIR
+    chown -R vcap:vcap $LOG_DIR
+
+    mkdir -p $RUN_DIR
+    chown -R vcap:vcap $RUN_DIR
+
+    mkdir -p $DATA_DIR
+    chown -R vcap:vcap $DATA_DIR
+
+    echo 'nameserver 127.0.0.1' > /etc/resolvconf/resolv.conf.d/head
+    if resolvconf --updates-are-enabled; then
+      resolvconf -u
+    else
+      if ! grep -q 127.0.0.1 /etc/resolv.conf; then
+        sed -i -e '1i nameserver 127.0.0.1' /etc/resolv.conf
+      fi
+    fi
+
+  setcap cap_net_bind_service=+ep $PKG/sbin/dnsmasq
+
+  chpst -u vcap:vcap $PKG/sbin/dnsmasq -C $CONF_DIR/dnsmasq.conf --pid-file=$PID_FILE
+
+  ;;
+  stop)
+    dnsmasq_pid=`head -1 $PID_FILE`
+    kill ${dnsmasq_pid} || true
+    wait ${dnsmasq_pid}
+  ;;
+
+  *)
+    echo "Usage: $0 {start|stop}"
+  ;;
+esac

--- a/packages/dnsmasq/packaging
+++ b/packages/dnsmasq/packaging
@@ -1,0 +1,10 @@
+# abort script on any command that exits with a non zero value
+set -e -x
+
+echo "extracting dnsmasq"
+
+tar xvfz dnsmasq/dnsmasq-2.75.tar.gz
+
+pushd dnsmasq-2.75
+  make install PREFIX=${BOSH_INSTALL_TARGET}
+popd

--- a/packages/dnsmasq/spec
+++ b/packages/dnsmasq/spec
@@ -1,0 +1,7 @@
+---
+name: dnsmasq
+
+dependencies:
+
+files:
+  - dnsmasq/dnsmasq-2.75.tar.gz  # http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.75.tar.gz


### PR DESCRIPTION
According to consul best practices we should only forward dns queries to consul which are part of the consul domain (e.g. cf.internal).

I added a dnsmasq job which routes dns queries based on the domain either to consul or the dns servers defined in the networks section of the instance.
