### PR TITLE
Allow configuration of domain and dns port

### DIFF
--- a/jobs/consul_agent/spec
+++ b/jobs/consul_agent/spec
@@ -37,6 +37,14 @@ properties:
     description: "Name of the agent's datacenter."
     default: dc1
 
+  consul.agent.domain:
+    description: "All queries in this domain are assumed to be handled by Consul and will not be recursively resolved."
+    default: cf.internal
+
+  consul.agent.ports.dns:
+    description: "The DNS server bind port."
+    default: 53
+
   consul.agent.services:
     description: "Map of consul service definitions."
     default: {}

--- a/src/confab/config/config.go
+++ b/src/confab/config/config.go
@@ -36,12 +36,18 @@ type ConfigConsulAgent struct {
 	Services        map[string]ServiceDefinition
 	Mode            string
 	Datacenter      string `json:"datacenter"`
+	Domain          string `json:"domain"`
+	Ports           ConfigConsulAgentPorts
 	LogLevel        string `json:"log_level"`
 	ProtocolVersion int    `json:"protocol_version"`
 }
 
 type ConfigConsulAgentServers struct {
 	LAN []string
+}
+
+type ConfigConsulAgentPorts struct {
+	DNS int `json:"dns"`
 }
 
 func Default() Config {

--- a/src/confab/config/config_test.go
+++ b/src/confab/config/config_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Config", func() {
 					"agent": {
 						"services": {
 							"myservice": {
-								"name" : "myservicename"	
+								"name" : "myservicename"
 							}
 						},
 						"mode": "server",
@@ -97,6 +97,43 @@ var _ = Describe("Config", func() {
 				},
 				Confab: config.ConfigConfab{
 					TimeoutInSeconds: 30,
+				},
+			}))
+		})
+
+		It("returns another config with given JSON", func() {
+			json := []byte(`{
+				"consul": {
+					"agent": {
+						"domain": "my-domain",
+						"ports": {
+							"dns": 8600
+						}
+					}
+				}
+			}`)
+			cfg, err := config.ConfigFromJSON(json)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg).To(Equal(config.Config{
+				Path: config.ConfigPath{
+					AgentPath:       "/var/vcap/packages/consul/bin/consul",
+					ConsulConfigDir: "/var/vcap/jobs/consul_agent/config",
+					PIDFile:         "/var/vcap/sys/run/consul_agent/consul_agent.pid",
+				},
+				Consul: config.ConfigConsul{
+					RequireSSL: true,
+					Agent: config.ConfigConsulAgent{
+						Servers: config.ConfigConsulAgentServers{
+							LAN: []string{},
+						},
+						Domain: "my-domain",
+						Ports: config.ConfigConsulAgentPorts{
+							DNS: 8600,
+						},
+					},
+				},
+				Confab: config.ConfigConfab{
+					TimeoutInSeconds: 55,
 				},
 			}))
 		})

--- a/src/confab/config/consul_config_definer.go
+++ b/src/confab/config/consul_config_definer.go
@@ -44,6 +44,16 @@ func GenerateConfiguration(config Config) ConsulConfig {
 		lan = []string{}
 	}
 
+	domain := "cf.internal"
+	if len(config.Consul.Agent.Domain) > 0 {
+		domain =  config.Consul.Agent.Domain
+	}
+
+	dnsPort := 53
+	if config.Consul.Agent.Ports.DNS > 1023 {
+		dnsPort = config.Consul.Agent.Ports.DNS
+	}
+
 	nodeName := strings.Replace(config.Node.Name, "_", "-", -1)
 	nodeName = fmt.Sprintf("%s-%d", nodeName, config.Node.Index)
 
@@ -51,13 +61,13 @@ func GenerateConfiguration(config Config) ConsulConfig {
 
 	consulConfig := ConsulConfig{
 		Server:     isServer,
-		Domain:     "cf.internal",
+		Domain:     domain,
 		Datacenter: config.Consul.Agent.Datacenter,
 		DataDir:    "/var/vcap/store/consul_agent",
 		LogLevel:   config.Consul.Agent.LogLevel,
 		NodeName:   nodeName,
 		Ports: ConsulConfigPorts{
-			DNS: 53,
+			DNS: dnsPort,
 		},
 		RejoinAfterLeave:   true,
 		RetryJoin:          lan,

--- a/src/confab/config/consul_config_definer_test.go
+++ b/src/confab/config/consul_config_definer_test.go
@@ -38,6 +38,19 @@ var _ = Describe("ConsulConfigDefiner", func() {
 			It("defaults to `cf.internal`", func() {
 				Expect(consulConfig.Domain).To(Equal("cf.internal"))
 			})
+
+			Context("when the `consul.agent.domain` property is set", func() {
+				It("uses that value", func() {
+					consulConfig = config.GenerateConfiguration(config.Config{
+						Consul: config.ConfigConsul{
+							Agent: config.ConfigConsulAgent{
+								Domain: "my-domain",
+							},
+						},
+					})
+					Expect(consulConfig.Domain).To(Equal("my-domain"))
+				})
+			})
 		})
 
 		Describe("data_dir", func() {
@@ -114,6 +127,40 @@ var _ = Describe("ConsulConfigDefiner", func() {
 				Expect(consulConfig.Ports).To(Equal(config.ConsulConfigPorts{
 					DNS: 53,
 				}))
+			})
+
+			Context("when the `consul.agent.ports.dns` property is set", func() {
+				It("uses that value", func() {
+					consulConfig = config.GenerateConfiguration(config.Config{
+						Consul: config.ConfigConsul{
+							Agent: config.ConfigConsulAgent{
+								Ports: config.ConfigConsulAgentPorts{
+									DNS: 8600,
+								},
+							},
+						},
+					})
+					Expect(consulConfig.Ports).To(Equal(config.ConsulConfigPorts{
+						DNS: 8600,
+					}))
+				})
+			})
+
+			Context("when the `consul.agent.ports.dns` property is set to a well-known port", func() {
+				It("uses that value", func() {
+					consulConfig = config.GenerateConfiguration(config.Config{
+						Consul: config.ConfigConsul{
+							Agent: config.ConfigConsulAgent{
+								Ports: config.ConfigConsulAgentPorts{
+									DNS: 1023,
+								},
+							},
+						},
+					})
+					Expect(consulConfig.Ports).To(Equal(config.ConsulConfigPorts{
+						DNS: 53,
+					}))
+				})
 			})
 		})
 


### PR DESCRIPTION
Hi @Amit-PivotalLabs, 

as you ask me to do. Here is the re-submitted PR against the develop branch. I will close the PR against master.

Many thanks for your fast reply.

-----

### Purpose

Extend the properties of the consul_agent job to allow configuration of  the consul agent [`domain`](https://www.consul.io/docs/agent/options.html#domain) and [`ports.dns`](https://www.consul.io/docs/agent/options.html#dns_port). With this enhancement it would be possible to deploy a second cluster with a different domain e.g `my.internal`. In order to avoid dns port conflicts and enable [DNS forwarding](https://www.consul.io/docs/guides/forwarding.html) the dns ports should be configurable. 

### Motivation

Currently we are using a fork the [Cloud Foundry Community - Consul BoshRelease](https://github.com/cloudfoundry-community/consul-boshrelease) as DNS and Service Discovery system for Backing Services. The dns names of this cluster must be resolvable on the `api` and `runner` job. On this vms there are already consul agents of the `cf.internal` consul cluster running. It is not possible to co-deploy a dnsmasq locally and use dns forwarding because the `cf.internal` agent has the fixed dns port 53. In order to get ride of two different consul bosh releases it would be great if the domain would be configurable.
 
### Proposal

Allow configuration of the consul agent [`domain`](https://www.consul.io/docs/agent/options.html#domain) and [`ports.dns`](https://www.consul.io/docs/agent/options.html#dns_port) to increase reusability of this release and to enable co-located agents of a different cluster on one vm.

### Changes

* added `consul.agent.domain` with default `cf.internal` to the consul agent job spec
* added `consul.agent.ports.dns` with default `53` to the consul agent job spec
* extended the structs in `confab/config/config.go` with these properties.
* modified the GenerateConfiguration function in `confab/config/consul_config_definer.go` to use these configuration properties if provided. Otherwise keep the previous defaults. It is not allowed to use a well-known port as dns port.
* added corresponding unit test.
 
### Tests

Changes were done and tested with a bosh-lite and openstack setup. The Confab Tests and Acceptance Tests completed successfully on both. The `./scripts/test` script has errors with and without my changes.

### CC

@vlerenc