### PR TITLE
Add Windows consul job

### DIFF
--- a/jobs/consul_agent_windows/monit
+++ b/jobs/consul_agent_windows/monit
@@ -1,0 +1,10 @@
+{
+  "processes": [
+    {
+      "name": "consul",
+      "executable": "C:\\var\\vcap\\packages\\consul-windows\\consul.exe",
+      "args": [ "agent", "-config-dir=/var/vcap/jobs/consul_agent_windows/config" ]
+    }
+  ]
+}
+

--- a/jobs/consul_agent_windows/spec
+++ b/jobs/consul_agent_windows/spec
@@ -1,0 +1,51 @@
+---
+name: consul_agent_windows
+templates:
+  agent.crt.erb: config/certs/agent.crt
+  agent.key.erb: config/certs/agent.key
+  ca.crt.erb: config/certs/ca.crt
+  config.json.erb: config/config.json
+
+packages:
+- consul-windows
+
+properties:
+  consul.agent.servers.lan:
+    description: "LAN server addresses to join on start."
+    default: []
+
+  consul.agent.servers.wan:
+    description: "WAN server addresses to join."
+    default: []
+
+  consul.agent.log_level:
+    description: "Agent log level."
+    default: info
+
+  consul.agent.datacenter:
+    description: "Name of the agent's datacenter."
+    default: dc1
+
+  consul.agent.services:
+    description: "Map of consul service definitions."
+    default: {}
+
+  consul.agent.protocol_version:
+    description: "The Consul protocol to use."
+    default: 2
+
+  consul.require_ssl:
+    description: "enable ssl for all communication with consul"
+    default: true
+
+  consul.ca_cert:
+    description: "PEM-encoded CA certificate"
+
+  consul.agent_cert:
+    description: "PEM-encoded agent certificate"
+
+  consul.agent_key:
+    description: "PEM-encoded client key"
+
+  consul.encrypt_keys:
+    description: "A list of passphrases that will be converted into encryption keys, the first key in the list is the active one"

--- a/jobs/consul_agent_windows/templates/agent.crt.erb
+++ b/jobs/consul_agent_windows/templates/agent.crt.erb
@@ -1,0 +1,3 @@
+<%=
+  p("consul.agent_cert") if p("consul.require_ssl")
+%>

--- a/jobs/consul_agent_windows/templates/agent.key.erb
+++ b/jobs/consul_agent_windows/templates/agent.key.erb
@@ -1,0 +1,3 @@
+<%=
+  p("consul.agent_key") if p("consul.require_ssl")
+%>

--- a/jobs/consul_agent_windows/templates/ca.crt.erb
+++ b/jobs/consul_agent_windows/templates/ca.crt.erb
@@ -1,0 +1,3 @@
+<%=
+  p("consul.ca_cert") if p("consul.require_ssl")
+%>

--- a/jobs/consul_agent_windows/templates/config.json.erb
+++ b/jobs/consul_agent_windows/templates/config.json.erb
@@ -1,0 +1,67 @@
+<%=
+  require 'openssl'
+  require 'base64'
+  def string_to_encrypt_key(string)
+    return string if is_key?(string)
+    Base64.strict_encode64(OpenSSL::PKCS5.pbkdf2_hmac_sha1(string, "", 20000, 16))
+  end
+  def is_key?(string)
+    Base64.strict_decode64(string).length == 16
+  rescue
+    false
+  end
+  def discover_external_ip
+    networks = spec.networks.marshal_dump
+    _, network = networks.find do |_name, network_spec|
+      network_spec.default
+    end
+    if !network
+      _, network = networks.first
+    end
+    if !network
+      raise "Could not determine IP via network spec: #{networks}"
+    end
+    network.ip
+  end
+  my_ip = discover_external_ip
+  lan_servers = p("consul.agent.servers.lan")
+  config = {
+    "datacenter" => p("consul.agent.datacenter"),
+    "domain" => "cf.internal",
+    "data_dir" => "/var/vcap/store/consul",
+    "log_level" => p("consul.agent.log_level"),
+    "node_name" => "#{name.gsub('_', '-')}-#{spec.index}",
+    "server" => false,
+    "ports" => {
+      "dns" => 53,
+    },
+    # without this, a single bootstrapped server will be orphaned after
+    # restarting
+    "rejoin_after_leave" => true,
+    "retry_join" => lan_servers,
+    # explicitly listen and advertise this job's IP; otherwise consul will pick
+    # an external IP, and possibly pick the wrong one (e.g. if containers are
+    # running on the VM)
+    "bind_addr" => my_ip,
+    # without this, a single bootstrapped server will be orphaned after
+    # restarting
+    "disable_remote_exec" => true,
+    "disable_update_check" => true,
+    "protocol" => p("consul.agent.protocol_version")
+  }
+if p("consul.require_ssl")
+  certs_dir = "/var/vcap/jobs/consul_agent_windows/config/certs"
+  key_file = "#{certs_dir}/agent.key"
+  cert_file = "#{certs_dir}/agent.crt"
+  config.merge!({
+    "verify_outgoing" => true,
+    "verify_incoming" => true,
+    "verify_server_hostname" => true,
+    "ca_file" => "#{certs_dir}/ca.crt",
+    "key_file" => key_file,
+    "cert_file" => cert_file,
+    "encrypt" => string_to_encrypt_key(p("consul.encrypt_keys").first),
+  })
+end
+  config.to_json
+%>

--- a/packages/consul-windows/packaging
+++ b/packages/consul-windows/packaging
@@ -1,0 +1,10 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+
+Unzip "consul-windows/consul_0.5.2_windows_386.zip" $Env:BOSH_INSTALL_TARGET

--- a/packages/consul-windows/spec
+++ b/packages/consul-windows/spec
@@ -1,0 +1,7 @@
+---
+name: consul-windows
+
+dependencies:
+
+files:
+- consul-windows/consul_0.5.2_windows_386.zip


### PR DESCRIPTION
Hi MEGA,

We're looking to start the conversation about adding a Windows version of the consul agent job to this release to support BOSH deployed Windows cells.

To get our config file we went back to the pre-confab `erb` file that used to be part of this repo. This probably isn't ideal, but it's going to be more of an endeavor to install go and compile confab on Windows than this. The other files are mostly just duplicates of the ones in the consul_agent dir, we could symlink them if that seems like it'd be better.

We don't currently see any need to run consul as a server on Windows, so we've made the job only really support running in client mode.

We weren't sure how adding a new blob in a PR should work, so we are leaving adding it to blobs.yml/uploading it to the S3 bucket to you. The blob we were using is from [here](https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_windows_386.zip).

[#118394997](https://www.pivotaltracker.com/story/show/118394997)