### PR TITLE
"Uploading a stemcell" section instructions should read `bosh upload stemcell`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We assume you have already deployed and targeted a BOSH director. For more instr
 
 ### 1. Uploading a stemcell
 
-Find the "BOSH Lite Warden" stemcell you wish to use. [bosh.io](https://bosh.io/stemcells) provides a resource to find and download stemcells.  Then run `bosh upload release STEMCELL_URL_OR_PATH_TO_DOWNLOADED_STEMCELL`.
+Find the "BOSH Lite Warden" stemcell you wish to use. [bosh.io](https://bosh.io/stemcells) provides a resource to find and download stemcells.  Then run `bosh upload stemcell STEMCELL_URL_OR_PATH_TO_DOWNLOADED_STEMCELL`.
 
 ### 2. Creating a release
 


### PR DESCRIPTION
"Uploading a stemcell" section instructions should read `bosh upload stemcell`