### PR TITLE
Support configurable confab configuration directory 

### DIFF
--- a/src/confab/chaperon/config_writer.go
+++ b/src/confab/chaperon/config_writer.go
@@ -25,7 +25,7 @@ func NewConfigWriter(dir string, logger logger) ConfigWriter {
 
 func (w ConfigWriter) Write(cfg config.Config) error {
 	w.logger.Info("config-writer.write.generate-configuration")
-	consulConfig := config.GenerateConfiguration(cfg)
+	consulConfig := config.GenerateConfiguration(cfg, w.dir)
 
 	data, err := json.Marshal(&consulConfig)
 	if err != nil {

--- a/src/confab/chaperon/config_writer_test.go
+++ b/src/confab/chaperon/config_writer_test.go
@@ -46,7 +46,7 @@ var _ = Describe("ConfigWriter", func() {
 
 			buf, err := ioutil.ReadFile(filepath.Join(configDir, "config.json"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(buf).To(MatchJSON(`{
+			Expect(buf).To(MatchJSON(fmt.Sprintf(`{
 				"server": false,
 				"domain": "",
 				"datacenter": "",
@@ -66,10 +66,10 @@ var _ = Describe("ConfigWriter", func() {
 				"verify_outgoing": true,
 				"verify_incoming": true,
 				"verify_server_hostname": true,
-				"ca_file": "/var/vcap/jobs/consul_agent/config/certs/ca.crt",
-				"key_file": "/var/vcap/jobs/consul_agent/config/certs/agent.key",
-				"cert_file": "/var/vcap/jobs/consul_agent/config/certs/agent.crt"
-			}`))
+				"ca_file": "%[1]s/certs/ca.crt",
+				"key_file": "%[1]s/certs/agent.key",
+				"cert_file": "%[1]s/certs/agent.crt"
+			}`, configDir)))
 
 			Expect(logger.Messages).To(ContainSequence([]fakes.LoggerMessage{
 				{
@@ -78,7 +78,7 @@ var _ = Describe("ConfigWriter", func() {
 				{
 					Action: "config-writer.write.write-file",
 					Data: []lager.Data{{
-						"config": config.GenerateConfiguration(cfg),
+						"config": config.GenerateConfiguration(cfg, configDir),
 					}},
 				},
 				{
@@ -102,7 +102,7 @@ var _ = Describe("ConfigWriter", func() {
 					{
 						Action: "config-writer.write.write-file",
 						Data: []lager.Data{{
-							"config": config.GenerateConfiguration(cfg),
+							"config": config.GenerateConfiguration(cfg, configDir),
 						}},
 					},
 					{

--- a/src/confab/confab/confab_test.go
+++ b/src/confab/confab/confab_test.go
@@ -176,7 +176,7 @@ var _ = Describe("confab", func() {
 
 			consulConfig, err := ioutil.ReadFile(filepath.Join(consulConfigDir, "config.json"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(consulConfig)).To(MatchJSON(`{
+			Expect(string(consulConfig)).To(MatchJSON(fmt.Sprintf(`{
 				"server": false,
 				"domain": "some-domain",
 				"datacenter": "dc1",
@@ -204,11 +204,11 @@ var _ = Describe("confab", func() {
 				"verify_outgoing": true,
 				"verify_incoming": true,
 				"verify_server_hostname": true,
-				"ca_file": "/var/vcap/jobs/consul_agent/config/certs/ca.crt",
-				"key_file": "/var/vcap/jobs/consul_agent/config/certs/agent.key",
-				"cert_file": "/var/vcap/jobs/consul_agent/config/certs/agent.crt",
+				"ca_file": "%[1]s/certs/ca.crt",
+				"key_file": "%[1]s/certs/agent.key",
+				"cert_file": "%[1]s/certs/agent.crt",
 				"encrypt": "enqzXBmgKOy13WIGsmUk+g=="
-			}`))
+			}`, consulConfigDir)))
 		})
 	})
 

--- a/src/confab/config/consul_config_definer.go
+++ b/src/confab/config/consul_config_definer.go
@@ -39,7 +39,7 @@ type ConsulConfigPorts struct {
 	DNS int `json:"dns"`
 }
 
-func GenerateConfiguration(config Config) ConsulConfig {
+func GenerateConfiguration(config Config, configDir string) ConsulConfig {
 	lan := config.Consul.Agent.Servers.LAN
 	if lan == nil {
 		lan = []string{}
@@ -77,7 +77,7 @@ func GenerateConfiguration(config Config) ConsulConfig {
 	consulConfig.VerifyOutgoing = boolPtr(true)
 	consulConfig.VerifyIncoming = boolPtr(true)
 	consulConfig.VerifyServerHostname = boolPtr(true)
-	certsDir := "/var/vcap/jobs/consul_agent/config/certs"
+	certsDir := filepath.Join(configDir, "certs")
 	consulConfig.CAFile = strPtr(filepath.Join(certsDir, "ca.crt"))
 
 	if isServer {

--- a/src/confab/config/consul_config_definer_test.go
+++ b/src/confab/config/consul_config_definer_test.go
@@ -181,7 +181,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								},
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.RetryJoinWAN).To(Equal([]string{
 						"first-wan-server",
 						"second-wan-server",

--- a/src/confab/config/consul_config_definer_test.go
+++ b/src/confab/config/consul_config_definer_test.go
@@ -10,9 +10,11 @@ import (
 var _ = Describe("ConsulConfigDefiner", func() {
 	Describe("GenerateConfiguration", func() {
 		var consulConfig config.ConsulConfig
+		var configDir string
 
 		BeforeEach(func() {
-			consulConfig = config.GenerateConfiguration(config.Config{})
+			configDir = "/var/vcap/jobs/consul_agent/config"
+			consulConfig = config.GenerateConfiguration(config.Config{}, configDir)
 		})
 
 		Describe("datacenter", func() {
@@ -28,7 +30,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								Datacenter: "my-datacenter",
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.Datacenter).To(Equal("my-datacenter"))
 				})
 			})
@@ -42,7 +44,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 							Domain: "some-domain",
 						},
 					},
-				})
+				}, configDir)
 
 				Expect(config.Domain).To(Equal("some-domain"))
 			})
@@ -67,7 +69,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								LogLevel: "some-log-level",
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.LogLevel).To(Equal("some-log-level"))
 				})
 			})
@@ -80,7 +82,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 						Name:  "node_name",
 						Index: 0,
 					},
-				})
+				}, configDir)
 				Expect(consulConfig.NodeName).To(Equal("node-name-0"))
 			})
 		})
@@ -98,7 +100,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								Mode: "server",
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.Server).To(BeTrue())
 				})
 			})
@@ -111,7 +113,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								Mode: "banana",
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.Server).To(BeFalse())
 				})
 			})
@@ -150,7 +152,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								},
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.RetryJoin).To(Equal([]string{
 						"first-server",
 						"second-server",
@@ -200,7 +202,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 						Node: config.ConfigNode{
 							ExternalIP: "0.0.0.0",
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.BindAddr).To(Equal("0.0.0.0"))
 				})
 			})
@@ -231,7 +233,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								ProtocolVersion: 21,
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.Protocol).To(Equal(21))
 				})
 			})
@@ -239,7 +241,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 
 		Describe("verify_outgoing", func() {
 			It("is true", func() {
-				consulConfig = config.GenerateConfiguration(config.Config{})
+				consulConfig = config.GenerateConfiguration(config.Config{}, configDir)
 				Expect(consulConfig.VerifyOutgoing).NotTo(BeNil())
 				Expect(*consulConfig.VerifyOutgoing).To(BeTrue())
 			})
@@ -247,7 +249,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 
 		Describe("verify_incoming", func() {
 			It("is true", func() {
-				consulConfig = config.GenerateConfiguration(config.Config{})
+				consulConfig = config.GenerateConfiguration(config.Config{}, configDir)
 				Expect(consulConfig.VerifyIncoming).NotTo(BeNil())
 				Expect(*consulConfig.VerifyIncoming).To(BeTrue())
 			})
@@ -255,7 +257,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 
 		Describe("verify_server_hostname", func() {
 			It("is true", func() {
-				consulConfig = config.GenerateConfiguration(config.Config{})
+				consulConfig = config.GenerateConfiguration(config.Config{}, configDir)
 				Expect(consulConfig.VerifyServerHostname).NotTo(BeNil())
 				Expect(*consulConfig.VerifyServerHostname).To(BeTrue())
 			})
@@ -263,9 +265,9 @@ var _ = Describe("ConsulConfigDefiner", func() {
 
 		Describe("ca_file", func() {
 			It("is the location of the ca file", func() {
-				consulConfig = config.GenerateConfiguration(config.Config{})
+				consulConfig = config.GenerateConfiguration(config.Config{}, "/var/vcap/jobs/consul_agent_windows/config")
 				Expect(consulConfig.CAFile).NotTo(BeNil())
-				Expect(*consulConfig.CAFile).To(Equal("/var/vcap/jobs/consul_agent/config/certs/ca.crt"))
+				Expect(*consulConfig.CAFile).To(Equal("/var/vcap/jobs/consul_agent_windows/config/certs/ca.crt"))
 			})
 		})
 
@@ -278,7 +280,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								Mode: "server",
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.KeyFile).NotTo(BeNil())
 					Expect(*consulConfig.KeyFile).To(Equal("/var/vcap/jobs/consul_agent/config/certs/server.key"))
 				})
@@ -286,7 +288,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 
 			Context("when `consul.agent.mode` is not `server`", func() {
 				It("is the location of the agent.key file", func() {
-					consulConfig = config.GenerateConfiguration(config.Config{})
+					consulConfig = config.GenerateConfiguration(config.Config{}, configDir)
 					Expect(consulConfig.KeyFile).NotTo(BeNil())
 					Expect(*consulConfig.KeyFile).To(Equal("/var/vcap/jobs/consul_agent/config/certs/agent.key"))
 				})
@@ -302,7 +304,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								Mode: "server",
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.CertFile).NotTo(BeNil())
 					Expect(*consulConfig.CertFile).To(Equal("/var/vcap/jobs/consul_agent/config/certs/server.crt"))
 				})
@@ -310,7 +312,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 
 			Context("when `consul.agent.mode` is not `server`", func() {
 				It("is the location of the agent.key file", func() {
-					consulConfig = config.GenerateConfiguration(config.Config{})
+					consulConfig = config.GenerateConfiguration(config.Config{}, configDir)
 					Expect(consulConfig.CertFile).NotTo(BeNil())
 					Expect(*consulConfig.CertFile).To(Equal("/var/vcap/jobs/consul_agent/config/certs/agent.crt"))
 				})
@@ -320,7 +322,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 		Describe("encrypt", func() {
 			Context("when `consul.encrypt_keys` is empty", func() {
 				It("is nil", func() {
-					consulConfig = config.GenerateConfiguration(config.Config{})
+					consulConfig = config.GenerateConfiguration(config.Config{}, configDir)
 					Expect(consulConfig.Encrypt).To(BeNil())
 				})
 			})
@@ -332,7 +334,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 							Consul: config.ConfigConsul{
 								EncryptKeys: []string{"banana"},
 							},
-						})
+						}, configDir)
 					Expect(consulConfig.Encrypt).NotTo(BeNil())
 					Expect(*consulConfig.Encrypt).To(Equal("enqzXBmgKOy13WIGsmUk+g=="))
 				})
@@ -343,7 +345,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 							Consul: config.ConfigConsul{
 								EncryptKeys: []string{"enqzXBmgKOy13WIGsmUk+g=="},
 							},
-						})
+						}, configDir)
 					Expect(consulConfig.Encrypt).NotTo(BeNil())
 					Expect(*consulConfig.Encrypt).To(Equal("enqzXBmgKOy13WIGsmUk+g=="))
 				})
@@ -372,7 +374,7 @@ var _ = Describe("ConsulConfigDefiner", func() {
 								},
 							},
 						},
-					})
+					}, configDir)
 					Expect(consulConfig.BootstrapExpect).NotTo(BeNil())
 					Expect(*consulConfig.BootstrapExpect).To(Equal(3))
 				})


### PR DESCRIPTION
This commit makes the path to the `confab` configuration directory configurable, `/var/vcap/jobs/consul_agent/config` remains the default, enabling support on Windows.  