### PR TITLE
Make consul_agent bind_addr configurable

### DIFF
--- a/jobs/consul_agent/spec
+++ b/jobs/consul_agent/spec
@@ -48,6 +48,9 @@ properties:
   consul.agent.domain:
     description: "Domain suffix for DNS"
 
+  consul.agent.bind_addr:
+    description: "Address to bind to."
+
   consul.ca_cert:
     description: "PEM-encoded CA certificate"
 

--- a/jobs/consul_agent/templates/confab.json.erb
+++ b/jobs/consul_agent/templates/confab.json.erb
@@ -1,9 +1,15 @@
 <%=
+  def external_ip
+    if_p("consul.agent.bind_addr") do |bind_addr|
+      return bind_addr
+    end
+    return spec.address
+  end
 {
   node: {
     name: name,
     index: spec.index,
-    external_ip: spec.address,
+    external_ip: external_ip
   },
   consul: p('consul')
 }.to_json


### PR DESCRIPTION
Signed-off-by: Trae Rawls <trawls@pivotal.io>

The PCF Dev team needs this change. Because we have multiple private IP addresses, the new version of consul won't start in pcfdev unless we explicitly set the bind address.