### PR TITLE
Make consul_agent bind address self-discoverable

### DIFF
--- a/jobs/consul_agent/templates/confab.json.erb
+++ b/jobs/consul_agent/templates/confab.json.erb
@@ -1,9 +1,24 @@
 <%=
+
+  def discover_external_ip
+    networks = spec.networks.marshal_dump
+
+    _, network = networks.find do |_name, network_spec|
+      network_spec.default
+    end
+
+    _, network = networks.first if network.nil?
+
+    raise "Could not determine IP via network spec: #{networks}" if network.nil?
+
+    network.ip
+  end
+
 {
   node: {
     name: name,
     index: spec.index,
-    external_ip: spec.address,
+    external_ip: spec.address || discover_external_ip,
   },
   consul: p('consul')
 }.to_json


### PR DESCRIPTION
Bring back old functionality for self-discovering external_ip, in case
`spec.address` is not available.

Signed-off-by: Anthony Emengo <aemengo@pivotal.io>