### PR TITLE
Add additional instructions for bosh-lite tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ brew install consul go jq
 
 #### BOSH-Lite
 
-Make sure you’ve run `bin/add-route`.
+Make sure you’ve run `bin/add-route` and `bin/enable_container_internet`.
 This will setup some routing rules to give the tests access to the consul VMs.
 
 #### AWS


### PR DESCRIPTION
This is an additional step that is helpful in setting up a bosh-lite
environment to run the acceptance tests

Signed-off-by: Amin Jamali <ajamali@pivotal.io>