### PR TITLE
Add consats windows jobs and packages

### DIFF
--- a/jobs/consul-test-consumer-windows/monit
+++ b/jobs/consul-test-consumer-windows/monit
@@ -1,0 +1,13 @@
+{
+  "processes": [
+    {
+      "name": "consul-test-consumer",
+      "executable": "C:\\var\\vcap\\packages\\acceptance-tests-windows\\bin\\testconsumer.exe",
+      "args": [
+        "--port", "6769",
+        "--consul-url", "http://127.0.0.1:8500",
+        "--path-to-check-a-record", "C:\\var\\vcap\\packages\\acceptance-tests-windows\\bin\\check-a-record.exe"
+      ]
+    }
+  ]
+}

--- a/jobs/consul-test-consumer-windows/spec
+++ b/jobs/consul-test-consumer-windows/spec
@@ -1,0 +1,13 @@
+---
+name: consul-test-consumer-windows
+templates:
+  pre-start.ps1.erb: bin/pre-start.ps1
+  dns_health_check.ps1: bin/dns_health_check.ps1
+
+packages:
+  - acceptance-tests-windows
+
+properties:
+  consul-test-consumer.nameserver:
+    description: "Nameserver to use to mock out responses/response times"
+    default: ""

--- a/jobs/consul-test-consumer-windows/templates/dns_health_check.ps1
+++ b/jobs/consul-test-consumer-windows/templates/dns_health_check.ps1
@@ -1,0 +1,15 @@
+$Address = "http://127.0.0.1:6769/health_check"
+$ExitCode = 0
+try {
+    Invoke-WebRequest "${Address}"
+} catch {
+    Write-Error "Error talking to: ${Address}"
+    Write-Error $_.Exception.Message
+    $ExitCode = 2
+}
+
+# Go struggles to capture the exit codes of
+# Windows commands/scripts that exit quickly
+Start-Sleep -Seconds 3
+
+Exit $ExitCode

--- a/jobs/consul-test-consumer-windows/templates/pre-start.ps1.erb
+++ b/jobs/consul-test-consumer-windows/templates/pre-start.ps1.erb
@@ -1,0 +1,113 @@
+$Error.Clear()
+
+try {
+  if (![bool](Test-WSMan -ErrorAction SilentlyContinue)) {
+    Enable-PSRemoting -Force
+  }
+
+  $RUN_DIR="C:\var\vcap\sys\run\consul-test-consumer-windows"
+  $LOG_DIR="C:\var\vcap\sys\log\consul-test-consumer-windows"
+  $PKG_DIR="C:\var\vcap\packages\acceptance-tests-windows"
+
+  New-Item -ItemType Directory -Force -Path "${RUN_DIR}"
+  New-Item -ItemType Directory -Force -Path "${LOG_DIR}"
+  New-Item -ItemType Directory -Force -Path "${PKG_DIR}"
+} catch {
+    Write-Error "Exception (consul-test-consumer-windows): pre-start.ps1"
+    Write-Error $_.Exception.Message
+    Exit 1
+}
+
+<% if !p("consul-test-consumer.nameserver").empty? %>
+
+  # Not Implemented:
+  #  - echo "options timeout:30" >> "${resolvconf_file}"
+
+  $nameserver=<%= p("consul-test-consumer.nameserver") %>
+
+  Configuration ConsulWindows {
+    Node "localhost" {
+
+      Script SetupDNS {
+        SetScript = {
+          [array]$routeable_interfaces = Get-WmiObject Win32_NetworkAdapterConfiguration | Where { $_.IpAddress -AND ($_.IpAddress | Where { $addr = [Net.IPAddress] $_; $addr.AddressFamily -eq "InterNetwork" -AND ($addr.address -BAND ([Net.IPAddress] "255.255.0.0").address) -ne ([Net.IPAddress] "169.254.0.0").address }) }
+          $ifindex = $routeable_interfaces[0].Index
+          $interface = (Get-WmiObject Win32_NetworkAdapter | Where { $_.DeviceID -eq $ifindex }).netconnectionid
+
+          $currentDNS = ((Get-DnsClientServerAddress -InterfaceAlias $interface) | where { $_.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork }).ServerAddresses
+
+          # Insert new record at index 1 matching behavior of:
+          #
+          #   `sed -i -e "2i nameserver $nameserver" "${resolvconf_file}"`
+          #
+          $newDNS = $currentDNS[0] + @("${nameserver}") + $currentDNS[1..$currentDNS.length]
+
+          Set-DnsClientServerAddress -InterfaceAlias $interface -ServerAddresses ($newDNS -join ",")
+        }
+        GetScript = {
+          return $false
+        }
+        TestScript = {
+          [array]$routeable_interfaces = Get-WmiObject Win32_NetworkAdapterConfiguration | Where { $_.IpAddress -AND ($_.IpAddress | Where { $addr = [Net.IPAddress] $_; $addr.AddressFamily -eq "InterNetwork" -AND ($addr.address -BAND ([Net.IPAddress] "255.255.0.0").address) -ne ([Net.IPAddress] "169.254.0.0").address }) }
+          $ifindex = $routeable_interfaces[0].Index
+          $interface = (Get-WmiObject Win32_NetworkAdapter | Where { $_.DeviceID -eq $ifindex }).netconnectionid
+
+          if((Get-DnsClientServerAddress -InterfaceAlias $interface -AddressFamily ipv4 -ErrorAction Stop).ServerAddresses[0] -eq "${nameserver}")
+          {
+            Write-Verbose -Message "DNS Servers are set correctly."
+            return $true
+          }
+          else
+          {
+            Write-Verbose -Message "DNS Servers not yet correct."
+            return $false
+          }
+        }
+      }
+
+      Script ClearDNSCache
+      {
+          SetScript = {
+              Clear-DnsClientCache
+          }
+          GetScript = {
+              Get-DnsClientCache
+          }
+          TestScript = {
+              @(Get-DnsClientCache).Count -eq 0
+          }
+      }
+
+      Registry DisableDNSNegativeCache
+      {
+          Ensure = "Present"
+          Key = "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters"
+          ValueName = "MaxNegativeCacheTtl"
+          ValueType = "DWord"
+          ValueData = "0"
+      }
+    }
+  }
+
+  Install-WindowsFeature DSC-Service
+  ConsulWindows
+  Start-DscConfiguration -Wait -Path .\ConsulWindows -Force -Verbose
+
+<% else %>
+
+  # Go struggles to capture the exit codes of
+  # Windows commands/scripts that exit quickly
+  Start-Sleep -Seconds 5
+
+<% end %>
+
+if ($Error) {
+    Write-Host "Error summary:"
+    foreach($ErrorMessage in $Error)
+    {
+      Write-Host $ErrorMessage
+    }
+    Exit 1
+}
+
+Exit 0

--- a/packages/acceptance-tests-windows/packaging
+++ b/packages/acceptance-tests-windows/packaging
@@ -1,0 +1,41 @@
+. ./exiter.ps1
+
+try {
+    $BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
+    $env:GO15VENDOREXPERIMENT = 1
+    $env:GOROOT = "C:\var\vcap\packages\golang1.6-windows\go"
+    $env:GOPATH = "${BOSH_INSTALL_TARGET}"
+    $env:PATH = "${env:GOROOT}\bin;${env:PATH}"
+
+    # acceptance-tests
+
+    Robocopy.exe /CREATE "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
+
+    Robocopy.exe /E "${PWD}/acceptance-tests" "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
+
+    # check-a-record
+    Robocopy.exe /CREATE "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/check-a-record"
+
+    Robocopy.exe /E "${PWD}/acceptance-tests/vendor/github.com/cloudfoundry-incubator/check-a-record" "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator"
+
+    go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/testing/testconsumer"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Error installing: testconsumer"
+        Exit 1
+    }
+    go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/testing/fake-dns-server"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Error installing: fake-dns-server"
+        Exit 1
+    }
+    go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/vendor/github.com/cloudfoundry-incubator/check-a-record"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Error installing: check-a-record"
+        Exit 1
+    }
+} catch {
+    Write-Error "Exception: installing acceptance-tests-windows"
+    Write-Error $_.Exception.Message
+    Exit 1
+}
+Exit 0

--- a/packages/acceptance-tests-windows/spec
+++ b/packages/acceptance-tests-windows/spec
@@ -1,0 +1,9 @@
+---
+name: acceptance-tests-windows
+
+dependencies:
+  - golang1.6-windows
+
+files:
+ - acceptance-tests/**/*
+ - exiter.ps1


### PR DESCRIPTION
This PR updates `consul-release` to include packages that will be used to run `Consats` on Windows.

These changes have been verified to produce a working `consul-test-consumer` on Windows deployments.