### PR TITLE
Add syslog to consul_agent_windows

### DIFF
--- a/jobs/consul_agent_windows/monit
+++ b/jobs/consul_agent_windows/monit
@@ -3,7 +3,12 @@
     {
       "name": "consul",
       "executable": "C:\\var\\vcap\\packages\\confab-windows\\bin\\confab.exe",
-      "args": [ "start", "", "-config-file", "/var/vcap/jobs/consul_agent_windows/confab.json", "-foreground" ]
+      "args": [ "start", "", "-config-file", "/var/vcap/jobs/consul_agent_windows/confab.json", "-foreground"],
+      "env": {
+        "__PIPE_SYSLOG_HOST": "<%= p('syslog_daemon_config.address') %>",
+        "__PIPE_SYSLOG_PORT": "<%= p('syslog_daemon_config.port') %>",
+        "__PIPE_SYSLOG_TRANSPORT": "<%= p('syslog_daemon_config.transport') %>"
+      }
     }
   ]
 }

--- a/jobs/consul_agent_windows/spec
+++ b/jobs/consul_agent_windows/spec
@@ -62,3 +62,13 @@ properties:
 
   consul.encrypt_keys:
     description: "A list of passphrases that will be converted into encryption keys, the first key in the list is the active one"
+
+  syslog_daemon_config.address:
+    description: "Syslog host"
+    default: ""
+  syslog_daemon_config.port:
+    description: "Syslog port"
+    default: ""
+  syslog_daemon_config.transport:
+    description: "Syslog transport protocol (tcp or udp)"
+    default: "udp"


### PR DESCRIPTION
A/C: As an operator I should be able to see logs from
`consul` in syslog destination `syslog_daemon_config` defined in my cf manifest.

The support for the new environment variables has been added to AWS
stemcell version 0.0.73 and above.

[#133698951]
https://www.pivotaltracker.com/story/show/133698951

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>
Signed-off-by: Amin Jamali <ajamali@pivotal.io>
Signed-off-by: Natalie Arellano <narellano@pivotal.io>