### PR TITLE
Fix powershell error handling and exit code.

### DIFF
--- a/jobs/consul-test-consumer-windows/templates/dns_health_check.ps1
+++ b/jobs/consul-test-consumer-windows/templates/dns_health_check.ps1
@@ -1,15 +1,11 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
 $Address = "http://127.0.0.1:6769/health_check"
-$ExitCode = 0
-try {
-    Invoke-WebRequest -UseBasicParsing "${Address}"
-} catch {
-    Write-Error "Error talking to: ${Address}"
-    Write-Error $_.Exception.Message
-    $ExitCode = 2
-}
+Invoke-WebRequest -UseBasicParsing "${Address}"
 
 # Go struggles to capture the exit codes of
 # Windows commands/scripts that exit quickly
 Start-Sleep -Seconds 3
 
-Exit $ExitCode
+Exit 0

--- a/jobs/consul-test-consumer-windows/templates/pre-start.ps1.erb
+++ b/jobs/consul-test-consumer-windows/templates/pre-start.ps1.erb
@@ -1,23 +1,21 @@
-try {
-  $RUN_DIR="C:\var\vcap\sys\run\consul-test-consumer-windows"
-  $LOG_DIR="C:\var\vcap\sys\log\consul-test-consumer-windows"
-  $PKG_DIR="C:\var\vcap\packages\acceptance-tests-windows"
-  New-Item -ItemType Directory -Force -Path "${RUN_DIR}"
-  New-Item -ItemType Directory -Force -Path "${LOG_DIR}"
-  New-Item -ItemType Directory -Force -Path "${PKG_DIR}"
-} catch {
-    Write-Error "Exception (consul-test-consumer-windows): pre-start.ps1"
-    Write-Error $_.Exception.Message
-    Exit 1
-}
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$RUN_DIR="C:\var\vcap\sys\run\consul-test-consumer-windows"
+$LOG_DIR="C:\var\vcap\sys\log\consul-test-consumer-windows"
+$PKG_DIR="C:\var\vcap\packages\acceptance-tests-windows"
+New-Item -ItemType Directory -Force -Path "${RUN_DIR}"
+New-Item -ItemType Directory -Force -Path "${LOG_DIR}"
+New-Item -ItemType Directory -Force -Path "${PKG_DIR}"
+
 <% if !p("consul-test-consumer.nameserver").empty? %>
-  # Not Implemented:
-  #  - echo "options timeout:30" >> "${resolvconf_file}"
-function DnsServers($interface) {
-  return (Get-DnsClientServerAddress -InterfaceAlias $interface -AddressFamily ipv4 -ErrorAction Stop).ServerAddresses
-}
-try {
-  $nameserver='<%= p("consul-test-consumer.nameserver") %>'
+    # Not Implemented:
+    #  - echo "options timeout:30" >> "${resolvconf_file}"
+    function DnsServers($interface) {
+      return (Get-DnsClientServerAddress -InterfaceAlias $interface -AddressFamily ipv4 -ErrorAction Stop).ServerAddresses
+    }
+
+    $nameserver='<%= p("consul-test-consumer.nameserver") %>'
     [array]$routeable_interfaces = Get-WmiObject Win32_NetworkAdapterConfiguration | Where { $_.IpAddress -AND ($_.IpAddress | Where { $addr = [Net.IPAddress] $_; $addr.AddressFamily -eq "InterNetwork" -AND ($addr.address -BAND ([Net.IPAddress] "255.255.0.0").address) -ne ([Net.IPAddress] "169.254.0.0").address }) }
     $ifindex = $routeable_interfaces[0].Index
     $interface = (Get-WmiObject Win32_NetworkAdapter | Where { $_.DeviceID -eq $ifindex }).netconnectionid
@@ -41,38 +39,28 @@ try {
             Exit 1
         }
     }
-} catch {
-    Write-Error "Exception (consul-test-consumer-windows): pre-start.ps1"
-    Write-Error $_.Exception.Message
-    Exit 1
-}
 <% end %>
-try {
+
+$status = (Get-NetFirewallRule -Name CFAllowConsulConsumer -ErrorAction Ignore).PrimaryStatus
+if ($status -ne "OK") {
+    $admins = New-Object System.Security.Principal.NTAccount("Administrators")
+    $adminsSid = $admins.Translate([System.Security.Principal.SecurityIdentifier])
+    $LocalUser = "D:(A;;CC;;;$adminsSid)"
+    $otherAdmins = Get-WmiObject win32_groupuser |
+        Where-Object { $_.GroupComponent -match 'administrators' } |
+        ForEach-Object { [wmi]$_.PartComponent }
+    foreach($admin in $otherAdmins)
+    {
+        $ntAccount = New-Object System.Security.Principal.NTAccount($admin.Name)
+        $sid = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
+        $LocalUser = $LocalUser + "(A;;CC;;;$sid)"
+    }
+    New-NetFirewallRule -Name CFAllowConsulConsumer -Description "Allow Consul-Consumer" `
+        -DisplayName "Allow Consul-Consumer" -Protocol TCP -LocalPort 6769 -Action allow -LocalUser $LocalUser
     $status = (Get-NetFirewallRule -Name CFAllowConsulConsumer -ErrorAction Ignore).PrimaryStatus
     if ($status -ne "OK") {
-        $admins = New-Object System.Security.Principal.NTAccount("Administrators")
-        $adminsSid = $admins.Translate([System.Security.Principal.SecurityIdentifier])
-        $LocalUser = "D:(A;;CC;;;$adminsSid)"
-        $otherAdmins = Get-WmiObject win32_groupuser |
-            Where-Object { $_.GroupComponent -match 'administrators' } |
-            ForEach-Object { [wmi]$_.PartComponent }
-        foreach($admin in $otherAdmins)
-        {
-            $ntAccount = New-Object System.Security.Principal.NTAccount($admin.Name)
-            $sid = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
-            $LocalUser = $LocalUser + "(A;;CC;;;$sid)"
-        }
-        New-NetFirewallRule -Name CFAllowConsulConsumer -Description "Allow Consul-Consumer" `
-            -DisplayName "Allow Consul-Consumer" -Protocol TCP -LocalPort 6769 -Action allow -LocalUser $LocalUser
-        $status = (Get-NetFirewallRule -Name CFAllowConsulConsumer -ErrorAction Ignore).PrimaryStatus
-        if ($status -ne "OK") {
-            Write-Error "Failed to Create CFAllowConsulConsumer Firewall rule"
-      Exit 1
+        Write-Error "Failed to Create CFAllowConsulConsumer Firewall rule"
     }
-    }
-} catch {
-    Write-Error "Exception (consul-test-consumer-windows): pre-start.ps1"
-    Write-Error $_.Exception.Message
-    Exit 1
 }
+
 Exit 0

--- a/jobs/consul_agent_windows/templates/pre-start.ps1.erb
+++ b/jobs/consul_agent_windows/templates/pre-start.ps1.erb
@@ -1,74 +1,56 @@
-try {
-    $LOG_DIR="/var/vcap/sys/log/consul_agent_windows"
-    $DATA_DIR="/var/vcap/data/consul_agent_windows"
-    $CONF_DIR="/var/vcap/jobs/consul_agent_windows/config"
-    $CERT_DIR="$CONF_DIR/certs"
-    New-Item -ItemType Directory -Force -Path "${LOG_DIR}"
-    New-Item -ItemType Directory -Force -Path "${DATA_DIR}"
-    New-Item -ItemType Directory -Force -Path "${CONF_DIR}"
-    New-Item -ItemType Directory -Force -Path "${CERT_DIR}"
-} catch {
-    Write-Error "Exception (consul_agent_windows): pre-start.ps1"
-    Write-Error $_.Exception.Message
-    Exit 1
-}
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$LOG_DIR="/var/vcap/sys/log/consul_agent_windows"
+$DATA_DIR="/var/vcap/data/consul_agent_windows"
+$CONF_DIR="/var/vcap/jobs/consul_agent_windows/config"
+$CERT_DIR="$CONF_DIR/certs"
+New-Item -ItemType Directory -Force -Path "${LOG_DIR}"
+New-Item -ItemType Directory -Force -Path "${DATA_DIR}"
+New-Item -ItemType Directory -Force -Path "${CONF_DIR}"
+New-Item -ItemType Directory -Force -Path "${CERT_DIR}"
+
 function DnsServers($interface) {
   return (Get-DnsClientServerAddress -InterfaceAlias $interface -AddressFamily ipv4 -ErrorAction Stop).ServerAddresses
 }
-try {
-    [array]$routeable_interfaces = Get-WmiObject Win32_NetworkAdapterConfiguration | Where { $_.IpAddress -AND ($_.IpAddress | Where { $addr = [Net.IPAddress] $_; $addr.AddressFamily -eq "InterNetwork" -AND ($addr.address -BAND ([Net.IPAddress] "255.255.0.0").address) -ne ([Net.IPAddress] "169.254.0.0").address }) }
-    $ifindex = $routeable_interfaces[0].Index
-    $interface = (Get-WmiObject Win32_NetworkAdapter | Where { $_.DeviceID -eq $ifindex }).netconnectionid
+
+[array]$routeable_interfaces = Get-WmiObject Win32_NetworkAdapterConfiguration | Where { $_.IpAddress -AND ($_.IpAddress | Where { $addr = [Net.IPAddress] $_; $addr.AddressFamily -eq "InterNetwork" -AND ($addr.address -BAND ([Net.IPAddress] "255.255.0.0").address) -ne ([Net.IPAddress] "169.254.0.0").address }) }
+$ifindex = $routeable_interfaces[0].Index
+$interface = (Get-WmiObject Win32_NetworkAdapter | Where { $_.DeviceID -eq $ifindex }).netconnectionid
+$servers = DnsServers($interface)
+
+if($servers[0] -eq "127.0.0.1")
+{
+    Write-Host "DNS Servers are set correctly."
+}
+else
+{
+    Write-Host "Setting DNS Servers"
+    $newDNS = "127.0.0.1", $servers
+    Write-Host $newDNS
+    Set-DnsClientServerAddress -InterfaceAlias $interface -ServerAddresses $newDNS
     $servers = DnsServers($interface)
-    if($servers[0] -eq "127.0.0.1")
-    {
-        Write-Host "DNS Servers are set correctly."
+    if($servers[0] -ne "127.0.0.1") {
+        Write-Error "Failed to set the DNS Servers"
     }
-    else
-    {
-        Write-Host "Setting DNS Servers"
-        $newDNS = "127.0.0.1", $servers
-        Write-Host $newDNS
-        Set-DnsClientServerAddress -InterfaceAlias $interface -ServerAddresses $newDNS
-        $servers = DnsServers($interface)
-        if($servers[0] -ne "127.0.0.1") {
-            Write-Error "Failed to set the DNS Servers"
-            Exit 1
-        }
-    }
-} catch {
-    Write-Error "Exception (consul_agent_windows): pre-start.ps1"
-    Write-Error $_.Exception.Message
-    Exit 1
 }
-try {
+
+if (@(Get-DnsClientCache).Count -ne 0) {
+    Clear-DnsClientCache
     if (@(Get-DnsClientCache).Count -ne 0) {
-        Clear-DnsClientCache
-        if (@(Get-DnsClientCache).Count -ne 0) {
-            Write-Error "Failed to clear DNS Client Cache"
-            Exit 1
-        }
+        Write-Error "Failed to clear DNS Client Cache"
     }
-} catch {
-    Write-Error "Exception (consul_agent_windows): pre-start.ps1"
-    Write-Error $_.Exception.Message
-    Exit 1
 }
-try {
-    $RegistryPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters"
-    $ExpectedValue = 0
+
+$RegistryPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters"
+$ExpectedValue = 0
+$Value = Get-ItemProperty -Path $RegistryPath
+if ($Value.MaxNegativeCacheTtl -ne $ExpectedValue) {
+    Set-ItemProperty -Path $RegistryPath -Name MaxNegativeCacheTtl -Value $ExpectedValue -Type DWord
     $Value = Get-ItemProperty -Path $RegistryPath
     if ($Value.MaxNegativeCacheTtl -ne $ExpectedValue) {
-        Set-ItemProperty -Path $RegistryPath -Name MaxNegativeCacheTtl -Value $ExpectedValue -Type DWord
-        $Value = Get-ItemProperty -Path $RegistryPath
-        if ($Value.MaxNegativeCacheTtl -ne $ExpectedValue) {
-            Write-Error "Error: Expected MaxNegativeCacheTtl to be '${ExpectedValue}', got '${Value.MaxNegativeCacheTtl}'"
-            Exit 1
-        }
+        Write-Error "Error: Expected MaxNegativeCacheTtl to be '${ExpectedValue}', got '${Value.MaxNegativeCacheTtl}'"
     }
-} catch {
-    Write-Error "Exception (consul_agent_windows): pre-start.ps1"
-    Write-Error $_.Exception.Message
-    Exit 1
 }
+
 Exit 0

--- a/jobs/consul_agent_windows/templates/pre-start.ps1.erb
+++ b/jobs/consul_agent_windows/templates/pre-start.ps1.erb
@@ -37,9 +37,6 @@ else
 
 if (@(Get-DnsClientCache).Count -ne 0) {
     Clear-DnsClientCache
-    if (@(Get-DnsClientCache).Count -ne 0) {
-        Write-Error "Failed to clear DNS Client Cache"
-    }
 }
 
 $RegistryPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters"

--- a/packages/acceptance-tests-windows/packaging
+++ b/packages/acceptance-tests-windows/packaging
@@ -1,41 +1,48 @@
 . ./exiter.ps1
 
-try {
-    $BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
-    $env:GO15VENDOREXPERIMENT = 1
-    $env:GOROOT = "C:\var\vcap\packages\golang1.7-windows\go"
-    $env:GOPATH = "${BOSH_INSTALL_TARGET}"
-    $env:PATH = "${env:GOROOT}\bin;${env:PATH}"
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
 
-    # acceptance-tests
+$BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
+$env:GO15VENDOREXPERIMENT = 1
+$env:GOROOT = "C:\var\vcap\packages\golang1.7-windows\go"
+$env:GOPATH = "${BOSH_INSTALL_TARGET}"
+$env:PATH = "${env:GOROOT}\bin;${env:PATH}"
 
-    Robocopy.exe /CREATE "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
+# acceptance-tests
 
-    Robocopy.exe /E "${PWD}/acceptance-tests" "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
-
-    # check-a-record
-    Robocopy.exe /CREATE "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/check-a-record"
-
-    Robocopy.exe /E "${PWD}/acceptance-tests/vendor/github.com/cloudfoundry-incubator/check-a-record" "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator"
-
-    go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/testing/testconsumer"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Error installing: testconsumer"
-        Exit 1
-    }
-    go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/testing/fake-dns-server"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Error installing: fake-dns-server"
-        Exit 1
-    }
-    go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/vendor/github.com/cloudfoundry-incubator/check-a-record"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Error installing: check-a-record"
-        Exit 1
-    }
-} catch {
-    Write-Error "Exception: installing acceptance-tests-windows"
-    Write-Error $_.Exception.Message
-    Exit 1
+Robocopy.exe /CREATE "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "Robocopy.exe /CREATE ${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
 }
+
+Robocopy.exe /E "${PWD}/acceptance-tests" "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "Robocopy.exe /E ${PWD}/acceptance-tests ${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests"
+}
+
+# check-a-record
+Robocopy.exe /CREATE "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/check-a-record"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "Robocopy.exe /CREATE ${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator/check-a-record"
+}
+
+Robocopy.exe /E "${PWD}/acceptance-tests/vendor/github.com/cloudfoundry-incubator/check-a-record" "${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "Robocopy.exe /E ${PWD}/acceptance-tests/vendor/github.com/cloudfoundry-incubator/check-a-record ${BOSH_INSTALL_TARGET}/src/github.com/cloudfoundry-incubator"
+}
+
+go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/testing/testconsumer"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error installing: testconsumer"
+}
+go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/testing/fake-dns-server"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error installing: fake-dns-server"
+}
+go.exe install "github.com/cloudfoundry-incubator/consul-release/src/acceptance-tests/vendor/github.com/cloudfoundry-incubator/check-a-record"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error installing: check-a-record"
+}
+
 Exit 0

--- a/packages/confab-windows/packaging
+++ b/packages/confab-windows/packaging
@@ -1,42 +1,39 @@
 . ./exiter.ps1
 
-try {
-    $BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
 
-    $env:GOROOT="C:\var\vcap\packages\golang1.7-windows\go"
-    $env:GOPATH="${BOSH_INSTALL_TARGET}"
-    $env:PATH="${env:GOROOT}\bin;${env:PATH}"
-    $env:GO15VENDOREXPERIMENT=1
-    $pkg_path="github.com\cloudfoundry-incubator\consul-release\src\confab\confab"
+$BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
 
-    New-Item -ItemType "directory" -Force "${BOSH_INSTALL_TARGET}\src\github.com\cloudfoundry-incubator\consul-release\src"
-    robocopy /E confab "${BOSH_INSTALL_TARGET}\src\github.com\cloudfoundry-incubator\consul-release\src\confab"
-    if ($LASTEXITCODE -ge 8) {
-        Exit 1
-    }
+$env:GOROOT="C:\var\vcap\packages\golang1.7-windows\go"
+$env:GOPATH="${BOSH_INSTALL_TARGET}"
+$env:PATH="${env:GOROOT}\bin;${env:PATH}"
+$env:GO15VENDOREXPERIMENT=1
+$pkg_path="github.com\cloudfoundry-incubator\consul-release\src\confab\confab"
 
-    go.exe install "${pkg_path}"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Error compiling: ${pkg_path}"
-        Exit 1
-    }
-
-    New-Item -ItemType "directory" -Force "emptyfolder"
-    robocopy /PURGE "emptyfolder" "${BOSH_INSTALL_TARGET}/src"
-    if ($LASTEXITCODE -ge 8) {
-        Exit 1
-    }
-    robocopy /PURGE "emptyfolder" "${BOSH_INSTALL_TARGET}/pkg"
-    if ($LASTEXITCODE -ge 8) {
-        Exit 1
-    }
-
-    Remove-Item -Force -Recurse "${BOSH_INSTALL_TARGET}/src"
-    Remove-Item -Force -Recurse "${BOSH_INSTALL_TARGET}/pkg"
-    Remove-Item -Force -Recurse "emptyfolder"
-} catch {
-    Write-Error $_.Exception.Message
-    Exit 1
+New-Item -ItemType "directory" -Force "${BOSH_INSTALL_TARGET}\src\github.com\cloudfoundry-incubator\consul-release\src"
+robocopy /E confab "${BOSH_INSTALL_TARGET}\src\github.com\cloudfoundry-incubator\consul-release\src\confab"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "robocopy /E confab ${BOSH_INSTALL_TARGET}\src\github.com\cloudfoundry-incubator\consul-release\src\confab"
 }
+
+go.exe install "${pkg_path}"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error compiling: ${pkg_path}"
+}
+
+New-Item -ItemType "directory" -Force "emptyfolder"
+robocopy /PURGE "emptyfolder" "${BOSH_INSTALL_TARGET}/src"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "robocopy /PURGE emptyfolder ${BOSH_INSTALL_TARGET}/src"
+}
+robocopy /PURGE "emptyfolder" "${BOSH_INSTALL_TARGET}/pkg"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "robocopy /PURGE emptyfolder ${BOSH_INSTALL_TARGET}/pkg"
+}
+
+Remove-Item -Force -Recurse "${BOSH_INSTALL_TARGET}/src"
+Remove-Item -Force -Recurse "${BOSH_INSTALL_TARGET}/pkg"
+Remove-Item -Force -Recurse "emptyfolder"
 
 Exit 0

--- a/packages/consul-windows/packaging
+++ b/packages/consul-windows/packaging
@@ -1,23 +1,19 @@
 . ./exiter.ps1
 
-try
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
 {
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    function Unzip
-    {
-        param([string]$zipfile, [string]$outpath)
+    param([string]$zipfile, [string]$outpath)
 
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
-    }
-
-    $BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
-
-    New-Item -ItemType "directory" -Force "${BOSH_INSTALL_TARGET}/bin"
-    Unzip "consul-windows/consul_0.7.1_windows_amd64.zip" "${BOSH_INSTALL_TARGET}/bin"
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
 }
-catch
-{
-    Write-Error $_.Exception.Message
-    Exit 1
-}
+
+$BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
+
+New-Item -ItemType "directory" -Force "${BOSH_INSTALL_TARGET}/bin"
+Unzip "consul-windows/consul_0.7.1_windows_amd64.zip" "${BOSH_INSTALL_TARGET}/bin"
+
 Exit 0


### PR DESCRIPTION
Stop script execution on error and return a non-zero exit code. Previously,
PowerShell happily plowed through errors with little regard for traps,
try catch blocks or the non-zero exits within them.

[#134462851]