### PR TITLE
Add `require_ssl` property to secure local agent

### DIFF
--- a/jobs/consul_agent_windows/spec
+++ b/jobs/consul_agent_windows/spec
@@ -47,6 +47,10 @@ properties:
   consul.agent.domain:
     description: "Domain suffix for DNS"
 
+  consul.agent.require_ssl:
+    description: "Require SSL to talk with the local agent"
+    default: true
+
   consul.rewrite_resolv:
     description: "When set to true this property will rewrite the resolv.conf file and add 127.0.0.1 as the first entry"
     default: true

--- a/src/confab/config/config.go
+++ b/src/confab/config/config.go
@@ -47,6 +47,7 @@ type ConfigConsulAgent struct {
 	DnsConfig       ConfigConsulAgentDnsConfig   `json:"dns_config"`
 	Bootstrap       bool                         `json:"bootstrap"`
 	NodeName        string                       `json:"node_name"`
+	RequireSSL      bool                         `json:"require_ssl"`
 }
 
 type ConfigConsulAgentDnsConfig struct {

--- a/src/confab/config/config_test.go
+++ b/src/confab/config/config_test.go
@@ -46,7 +46,8 @@ var _ = Describe("Config", func() {
 								"allow_stale": true,
 								"max_stale": "15s",
 								"recursor_timeout": "15s"
-							}
+							},
+							"require_ssl": true
 						},
 						"encrypt_keys": ["key-1", "key-2"]
 					},
@@ -91,6 +92,7 @@ var _ = Describe("Config", func() {
 								MaxStale:        "15s",
 								RecursorTimeout: "15s",
 							},
+							RequireSSL: true,
 						},
 						EncryptKeys: []string{"key-1", "key-2"},
 					},

--- a/src/confab/config/consul_config_definer.go
+++ b/src/confab/config/consul_config_definer.go
@@ -34,7 +34,9 @@ type ConsulConfig struct {
 }
 
 type ConsulConfigPorts struct {
-	DNS int `json:"dns,omitempty"`
+	DNS   int `json:"dns,omitempty"`
+	HTTP  int `json:"http,omitempty"`
+	HTTPS int `json:"https,omitempty"`
 }
 
 type ConsulConfigDnsConfig struct {
@@ -83,6 +85,11 @@ func GenerateConfiguration(config Config, configDir, nodeName string) ConsulConf
 		Performance: ConsulConfigPerformance{
 			RaftMultiplier: 1,
 		},
+	}
+
+	if config.Consul.Agent.RequireSSL {
+		consulConfig.Ports.HTTP = -1
+		consulConfig.Ports.HTTPS = 8500
 	}
 
 	consulConfig.VerifyOutgoing = boolPtr(true)

--- a/src/confab/config/consul_config_definer_test.go
+++ b/src/confab/config/consul_config_definer_test.go
@@ -209,9 +209,35 @@ var _ = Describe("ConsulConfigDefiner", func() {
 			})
 		})
 
-		Describe("DNS port", func() {
-			It("defaults to 53", func() {
-				Expect(consulConfig.Ports.DNS).To(Equal(53))
+		Describe("ports", func() {
+			Describe("DNS port", func() {
+				It("defaults to 53", func() {
+					Expect(consulConfig.Ports.DNS).To(Equal(53))
+				})
+			})
+
+			Context("when `consul.agent.require_ssl` is true", func() {
+				BeforeEach(func() {
+					consulConfig = config.GenerateConfiguration(config.Config{
+						Consul: config.ConfigConsul{
+							Agent: config.ConfigConsulAgent{
+								RequireSSL: true,
+							},
+						},
+					}, configDir, "")
+				})
+
+				Describe("HTTP port", func() {
+					It("is disabled", func() {
+						Expect(consulConfig.Ports.HTTP).To(Equal(-1))
+					})
+				})
+
+				Describe("HTTPS port", func() {
+					It("defaults to 8500", func() {
+						Expect(consulConfig.Ports.HTTPS).To(Equal(8500))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
This PR adds a property to the `consul_agent_windows` job to require SSL when communicating over localhost. The HTTP port is disabled when this property is specified and the HTTPS port is set to 8500.

The requisite unit tests pass on *nix and Windows.