### PR TITLE
Additional changes required to secure consul agent HTTP API

### DIFF
--- a/scripts/generate-certs
+++ b/scripts/generate-certs
@@ -23,8 +23,15 @@ mv -f ${depot_path}/$server_cn.csr ${depot_path}/server.csr
 mv -f ${depot_path}/$server_cn.crt ${depot_path}/server.crt
 
 # Agent certificate to distribute to jobs that access consul
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'consul agent'
+certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'consul agent' --ip '127.0.0.1'
 certstrap --depot-path ${depot_path} sign consul_agent --CA server-ca
 mv -f ${depot_path}/consul_agent.key ${depot_path}/agent.key
 mv -f ${depot_path}/consul_agent.csr ${depot_path}/agent.csr
 mv -f ${depot_path}/consul_agent.crt ${depot_path}/agent.crt
+
+# Client certificate to distribute to jobs that access the consul agent API
+certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'consul agent api'
+certstrap --depot-path ${depot_path} sign consul_agent_api --CA server-ca
+mv -f ${depot_path}/consul_agent_api.key ${depot_path}/agent_api.key
+mv -f ${depot_path}/consul_agent_api.csr ${depot_path}/agent_api.csr
+mv -f ${depot_path}/consul_agent_api.crt ${depot_path}/agent_api.crt

--- a/src/confab/confab/main.go
+++ b/src/confab/confab/main.go
@@ -110,7 +110,8 @@ func main() {
 		}
 		tlsClientConfig, err := api.SetupTLSConfig(&tlsConfig)
 		if err != nil {
-			panic(err)
+			stderr.Printf("error setting up TLS config: %s", err)
+			os.Exit(1)
 		}
 		if transport, ok := clientConfig.HttpClient.Transport.(*http.Transport); ok {
 			transport.TLSClientConfig = tlsClientConfig

--- a/src/confab/confab/main.go
+++ b/src/confab/confab/main.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"code.cloudfoundry.org/clock"
@@ -96,7 +98,26 @@ func main() {
 		Logger:    logger,
 	}
 
-	consulAPIClient, err := api.NewClient(api.DefaultConfig())
+	clientConfig := api.DefaultConfig()
+	if cfg.Consul.Agent.RequireSSL {
+		clientConfig.Scheme = "https"
+		certsDir := filepath.Join(cfg.Path.ConsulConfigDir, "certs")
+		tlsConfig := api.TLSConfig{
+			Address:  clientConfig.Address,
+			CAFile:   filepath.Join(certsDir, "ca.crt"),
+			CertFile: filepath.Join(certsDir, "agent.crt"),
+			KeyFile:  filepath.Join(certsDir, "agent.key"),
+		}
+		tlsClientConfig, err := api.SetupTLSConfig(&tlsConfig)
+		if err != nil {
+			panic(err)
+		}
+		if transport, ok := clientConfig.HttpClient.Transport.(*http.Transport); ok {
+			transport.TLSClientConfig = tlsClientConfig
+		}
+	}
+
+	consulAPIClient, err := api.NewClient(clientConfig)
 	if err != nil {
 		panic(err) // not tested, NewClient never errors
 	}


### PR DESCRIPTION
Hey,

We noticed that a commit was missing from our last PR to secure the consul agent. The additional commit in this PR allows the consul healthcheck to pass when TLS is required to talk to the agent.

Also, an IP Subject Alternate Name must be present in the agent cert in order for HTTP API connections to succeed when TLS Is required. So we've update the cert generation script to include this.

We also generate a new consul HTTP client API cert and key so that clients can actually use the new authentication mechanism.