### PR TITLE
Provide and optionally consume a consul link

### DIFF
--- a/jobs/consul_agent/spec
+++ b/jobs/consul_agent/spec
@@ -8,6 +8,7 @@ templates:
   pre-start.erb: bin/pre-start
   drain: bin/drain
   confab.json.erb: confab.json
+  consul_link.json.erb: consul_link.json
   ca.crt.erb: config/certs/ca.crt
   server.crt.erb: config/certs/server.crt
   server.key.erb: config/certs/server.key
@@ -17,6 +18,30 @@ templates:
 packages:
   - consul
   - confab
+
+provides:
+- name: consul
+  type: consul
+  properties:
+  - consul.agent.servers.lan
+  - consul.agent.log_level
+  - consul.agent.datacenter
+  - consul.agent.protocol_version
+  - consul.agent.dns_config.allow_stale
+  - consul.agent.dns_config.max_stale
+  - consul.agent.dns_config.recursor_timeout
+  - consul.agent.domain
+  - consul.ca_cert
+  - consul.server_cert
+  - consul.server_key
+  - consul.agent_cert
+  - consul.agent_key
+  - consul.encrypt_keys
+
+consumes:
+- name: consul
+  type: consul
+  optional: true
 
 properties:
   consul.agent.mode:

--- a/jobs/consul_agent/templates/agent.crt.erb
+++ b/jobs/consul_agent/templates/agent.crt.erb
@@ -1,3 +1,11 @@
 <%=
-  p("consul.agent_cert") if p("consul.agent.mode") == "client"
+  agent_cert = nil
+
+  respond_to?(:if_link) && if_link("consul") do |link|
+    agent_cert = link.p("consul.agent_cert")
+  end.else do
+    agent_cert = p("consul.agent_cert")
+  end
+
+  agent_cert if p("consul.agent.mode") == "client"
 %>

--- a/jobs/consul_agent/templates/agent.key.erb
+++ b/jobs/consul_agent/templates/agent.key.erb
@@ -1,3 +1,11 @@
 <%=
-  p("consul.agent_key") if p("consul.agent.mode") == "client"
+  agent_key = nil
+
+  respond_to?(:if_link) && if_link("consul") do |link|
+    agent_key = link.p("consul.agent_key")
+  end.else do
+    agent_key = p("consul.agent_key")
+  end
+
+  agent_key if p("consul.agent.mode") == "client"
 %>

--- a/jobs/consul_agent/templates/agent_ctl.sh.erb
+++ b/jobs/consul_agent/templates/agent_ctl.sh.erb
@@ -24,6 +24,7 @@ function start_confab() {
     start \
     ${recursors} \
     --config-file "${JOB_DIR}/confab.json" \
+    --config-consul-link-file "${JOB_DIR}/consul_link.json" \
     1> >(tee -a ${LOG_DIR}/consul_agent.stdout.log | logger -p user.info -t vcap.consul-agent) \
     2> >(tee -a ${LOG_DIR}/consul_agent.stderr.log | logger -p user.error -t vcap.consul-agent)
 }
@@ -32,6 +33,7 @@ function stop_confab() {
   "${CONFAB_PACKAGE}/bin/confab" \
     stop \
     --config-file "${JOB_DIR}/confab.json" \
+    --config-consul-link-file "${JOB_DIR}/consul_link.json" \
     1> >(tee -a ${LOG_DIR}/consul_agent.stdout.log | logger -p user.info -t vcap.consul-agent) \
     2> >(tee -a ${LOG_DIR}/consul_agent.stderr.log | logger -p user.error -t vcap.consul-agent)
 }

--- a/jobs/consul_agent/templates/ca.crt.erb
+++ b/jobs/consul_agent/templates/ca.crt.erb
@@ -1,3 +1,11 @@
 <%=
-  p("consul.ca_cert")
+  ca_cert = nil
+
+  respond_to?(:if_link) && if_link("consul") do |link|
+    ca_cert = link.p("consul.ca_cert")
+  end.else do
+    ca_cert = p("consul.ca_cert")
+  end
+
+  ca_cert
 %>

--- a/jobs/consul_agent/templates/consul_link.json.erb
+++ b/jobs/consul_agent/templates/consul_link.json.erb
@@ -1,0 +1,9 @@
+<%=
+  consul_hash = {}
+
+  respond_to?(:if_link) && if_link('consul') do |consul_link|
+    consul_hash = consul_link.p('consul')
+  end
+
+  consul_hash.to_json
+%>

--- a/jobs/consul_agent/templates/server.crt.erb
+++ b/jobs/consul_agent/templates/server.crt.erb
@@ -1,3 +1,11 @@
 <%=
-  p("consul.server_cert") if p("consul.agent.mode") == "server"
+  server_cert = nil
+
+  respond_to?(:if_link) && if_link("consul") do |link|
+    server_cert = link.p("consul.server_cert")
+  end.else do
+    server_cert = p("consul.server_cert")
+  end
+
+  server_cert if p("consul.agent.mode") == "server"
 %>

--- a/jobs/consul_agent/templates/server.key.erb
+++ b/jobs/consul_agent/templates/server.key.erb
@@ -1,3 +1,11 @@
 <%=
-  p("consul.server_key")if p("consul.agent.mode") == "server"
+  server_key = nil
+
+  respond_to?(:if_link) && if_link("consul") do |link|
+    server_key = link.p("consul.server_key")
+  end.else do
+    server_key = p("consul.server_key")
+  end
+
+  server_key if p("consul.agent.mode") == "server"
 %>

--- a/src/confab/confab/confab_test.go
+++ b/src/confab/confab/confab_test.go
@@ -23,11 +23,12 @@ const POLL_INTERVAL = time.Millisecond * 250
 
 var _ = Describe("confab", func() {
 	var (
-		tempDir         string
-		dataDir         string
-		consulConfigDir string
-		pidFile         *os.File
-		configFile      *os.File
+		tempDir              string
+		dataDir              string
+		consulConfigDir      string
+		pidFile              *os.File
+		configFile           *os.File
+		configConsulLinkFile *os.File
 	)
 
 	BeforeEach(func() {
@@ -56,6 +57,14 @@ var _ = Describe("confab", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		writeConfigurationFile(configFile.Name(), map[string]interface{}{})
+
+		configConsulLinkFile, err = ioutil.TempFile(tempDir, "config-consul-link-file")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = configConsulLinkFile.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		writeConfigurationFile(configConsulLinkFile.Name(), map[string]interface{}{})
 
 		options := []byte(`{"Members": ["member-1", "member-2", "member-3"]}`)
 		err = ioutil.WriteFile(filepath.Join(consulConfigDir, "options.json"), options, 0600)
@@ -126,6 +135,7 @@ var _ = Describe("confab", func() {
 			stop := exec.Command(pathToConfab,
 				"stop",
 				"--config-file", configFile.Name(),
+				"--config-consul-link-file", configConsulLinkFile.Name(),
 			)
 			Eventually(stop.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -227,6 +237,7 @@ var _ = Describe("confab", func() {
 				"--recursor", "8.8.8.8",
 				"--recursor", "10.0.2.3",
 				"--config-file", configFile.Name(),
+				"--config-consul-link-file", configConsulLinkFile.Name(),
 			)
 			Eventually(start.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -244,6 +255,7 @@ var _ = Describe("confab", func() {
 				"--recursor", "8.8.8.8",
 				"--recursor", "10.0.2.3",
 				"--config-file", configFile.Name(),
+				"--config-consul-link-file", configConsulLinkFile.Name(),
 			)
 			Eventually(start.Start, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -276,6 +288,7 @@ var _ = Describe("confab", func() {
 				"--recursor", "8.8.8.8",
 				"--recursor", "10.0.2.3",
 				"--config-file", configFile.Name(),
+				"--config-consul-link-file", configConsulLinkFile.Name(),
 			)
 			Eventually(start.Start, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -336,6 +349,7 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"start",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -384,6 +398,7 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"start",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -457,6 +472,7 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"start",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 
 				start := time.Now()
@@ -499,6 +515,7 @@ var _ = Describe("confab", func() {
 			cmd := exec.Command(pathToConfab,
 				"start",
 				"--config-file", configFile.Name(),
+				"--config-consul-link-file", configConsulLinkFile.Name(),
 			)
 			Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -516,6 +533,7 @@ var _ = Describe("confab", func() {
 			cmd = exec.Command(pathToConfab,
 				"stop",
 				"--config-file", configFile.Name(),
+				"--config-consul-link-file", configConsulLinkFile.Name(),
 			)
 			Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
@@ -580,6 +598,7 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"--recursor=8.8.8.8",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
@@ -592,7 +611,8 @@ var _ = Describe("confab", func() {
 		Context("when an invalid command is provided", func() {
 			It("returns a non-zero status code and prints usage", func() {
 				cmd := exec.Command(pathToConfab, "banana",
-					"--config-file", configFile.Name())
+					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name())
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).ShouldNot(Succeed())
@@ -604,7 +624,8 @@ var _ = Describe("confab", func() {
 		Context("expected-member is missing", func() {
 			It("prints an error and usage", func() {
 				cmd := exec.Command(pathToConfab, "start",
-					"--config-file", configFile.Name())
+					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name())
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).ShouldNot(Succeed())
@@ -634,7 +655,8 @@ var _ = Describe("confab", func() {
 
 			It("prints an error and usage", func() {
 				cmd := exec.Command(pathToConfab, "start",
-					"--config-file", configFile.Name())
+					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name())
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).ShouldNot(Succeed())
@@ -664,7 +686,8 @@ var _ = Describe("confab", func() {
 
 			It("prints an error and usage", func() {
 				cmd := exec.Command(pathToConfab, "start",
-					"--config-file", configFile.Name())
+					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name())
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).ShouldNot(Succeed())
@@ -694,7 +717,8 @@ var _ = Describe("confab", func() {
 
 			It("prints an error and usage", func() {
 				cmd := exec.Command(pathToConfab, "start",
-					"--config-file", configFile.Name())
+					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name())
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).ShouldNot(Succeed())
@@ -726,12 +750,14 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"start",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 				Eventually(cmd.Run, COMMAND_TIMEOUT, COMMAND_TIMEOUT).Should(Succeed())
 
 				cmd = exec.Command(pathToConfab,
 					"start",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 
 				stdout := bytes.NewBuffer([]byte{})
@@ -780,6 +806,7 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"start",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
@@ -832,6 +859,7 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"start",
 					"--config-file", tmpFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer
@@ -879,6 +907,7 @@ var _ = Describe("confab", func() {
 				cmd := exec.Command(pathToConfab,
 					"start",
 					"--config-file", configFile.Name(),
+					"--config-consul-link-file", configConsulLinkFile.Name(),
 				)
 				buffer := bytes.NewBuffer([]byte{})
 				cmd.Stderr = buffer

--- a/src/confab/confab/main.go
+++ b/src/confab/confab/main.go
@@ -42,9 +42,10 @@ func (ss *stringSlice) Set(value string) error {
 }
 
 var (
-	recursors  stringSlice
-	configFile string
-	foreground bool
+	recursors            stringSlice
+	configFile           string
+	configConsulLinkFile string
+	foreground           bool
 
 	stdout = log.New(os.Stdout, "", 0)
 	stderr = log.New(os.Stderr, "", 0)
@@ -54,6 +55,7 @@ func main() {
 	flagSet := flag.NewFlagSet("flags", flag.ContinueOnError)
 	flagSet.Var(&recursors, "recursor", "specifies the address of an upstream DNS `server`, may be specified multiple times")
 	flagSet.StringVar(&configFile, "config-file", "", "specifies the config `file`")
+	flagSet.StringVar(&configConsulLinkFile, "config-consul-link-file", "", "specifies the consul link config `file`")
 	flagSet.BoolVar(&foreground, "foreground", false, "if true confab will wait for consul to exit")
 
 	if len(os.Args) < 2 {
@@ -70,7 +72,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg, err := config.ConfigFromJSON(configFileContents)
+	configConsulLinkFileContents, err := ioutil.ReadFile(configConsulLinkFile)
+	if err != nil {
+		stderr.Printf("error reading configuration file: %s", err)
+		os.Exit(1)
+	}
+
+	cfg, err := config.ConfigFromJSON(configFileContents, configConsulLinkFileContents)
 	if err != nil {
 		stderr.Printf("error reading configuration file: %s", err)
 		os.Exit(1)

--- a/src/confab/config/config.go
+++ b/src/confab/config/config.go
@@ -92,12 +92,18 @@ func defaultConfig() Config {
 	}
 }
 
-func ConfigFromJSON(configData []byte) (Config, error) {
+func ConfigFromJSON(configData, configConsulLinkData []byte) (Config, error) {
 	config := defaultConfig()
 
 	if err := json.Unmarshal(configData, &config); err != nil {
 		return Config{}, err
 	}
+
+	configConsul, err := mergedConsulConfig(config.Consul, configConsulLinkData)
+	if err != nil {
+		return Config{}, err
+	}
+	config.Consul = configConsul
 
 	if config.Path.DataDir == "" {
 		if config.Consul.Agent.Mode == "server" {
@@ -112,4 +118,14 @@ func ConfigFromJSON(configData []byte) (Config, error) {
 	}
 
 	return config, nil
+}
+
+func mergedConsulConfig(configConsul ConfigConsul, configConsulLinkData []byte) (ConfigConsul, error) {
+	if len(configConsulLinkData) > 0 {
+		if err := json.Unmarshal(configConsulLinkData, &configConsul); err != nil {
+			return ConfigConsul{}, err
+		}
+	}
+
+	return configConsul, nil
 }


### PR DESCRIPTION
- This greatly reduces the configuration required by an operator when
  the agent is in client mode.
- This has added one new required configuration file for loading link
  information about consul: `--config-consul-link-file`
- If a property is specified as both a linked and non-linked property,
  the linked property will take precedence

[#132721819]

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>