### PR TITLE
Always remove DNS lock in consul_agen_windows pre-start

### DIFF
--- a/jobs/consul_agent_windows/templates/pre-start.ps1.erb
+++ b/jobs/consul_agent_windows/templates/pre-start.ps1.erb
@@ -1,5 +1,8 @@
-$ErrorActionPreference = "Stop";
-trap { $host.SetShouldExit(1) }
+﻿$ErrorActionPreference = "Stop";
+trap {
+  ReleaseDNSLock
+  $host.SetShouldExit(1)
+}
 
 $LOG_DIR="/var/vcap/sys/log/consul_agent_windows"
 $DATA_DIR="/var/vcap/data/consul_agent_windows"
@@ -28,10 +31,11 @@ function WaitForDNSLock() {
 }
 
 function ReleaseDNSLock() {
-  Remove-Item C:\var\vcap\sys\run\consul-dns.lock
+  Remove-Item C:\var\vcap\sys\run\consul-dns.lock -ErrorAction Ignore
 }
 
 WaitForDNSLock
+
 [array]$routeable_interfaces = Get-WmiObject Win32_NetworkAdapterConfiguration | Where { $_.IpAddress -AND ($_.IpAddress | Where { $addr = [Net.IPAddress] $_; $addr.AddressFamily -eq "InterNetwork" -AND ($addr.address -BAND ([Net.IPAddress] "255.255.0.0").address) -ne ([Net.IPAddress] "169.254.0.0").address }) }
 $ifindex = $routeable_interfaces[0].Index
 $interface = (Get-WmiObject Win32_NetworkAdapter | Where { $_.DeviceID -eq $ifindex }).netconnectionid
@@ -54,12 +58,13 @@ else
     if($servers[0] -ne "127.0.0.1") {
         Write-Error "Failed to set the DNS Servers"
     }
-    ReleaseDNSLock
 }
 <% elsif rewrite_resolv != false %>
 Write-Error "Error: rewrite_resolv property must be a boolean"
 Exit 1
 <% end %>
+
+ReleaseDNSLock
 
 if (@(Get-DnsClientCache).Count -ne 0) {
     Clear-DnsClientCache


### PR DESCRIPTION
Consul agent on Windows writes a lock file, but doesn't always clean it up. This causes an infinite loop when pre-start is run a second time.

This fix releases the DNS lock every time.