### PR TITLE
Allow agent node name to be set for confab.

### DIFF
--- a/jobs/consul_agent/spec
+++ b/jobs/consul_agent/spec
@@ -60,6 +60,9 @@ consumes:
   optional: true
 
 properties:
+  consul.agent.node_name:
+    description: "Node name for the agent. (Defaults to the BOSH instance group name)"
+
   consul.agent.mode:
     description: "Mode to run the agent in. (client or server)"
     default: client

--- a/jobs/consul_agent/templates/confab.json.erb
+++ b/jobs/consul_agent/templates/confab.json.erb
@@ -17,9 +17,17 @@
   network.ip
   end
 
+  node_name = nil
+
+  if_p("consul.agent.node_name") do |prop|
+    node_name = prop
+  end.else do
+    node_name = name
+  end
+
   {
     node: {
-      name: name,
+      name: node_name,
       index: spec.index,
       external_ip: discover_external_ip,
       zone: spec.az,


### PR DESCRIPTION
This allows multiple deployments of the same bosh job to co-exist and
connect to a consul cluster without duplicate name errors.

On-demand services would need to include the service ID in the job name otherwise, because all on-demand instances will have the same job name.