### PR TITLE
allow for registering unique node names with consul

### DIFF
--- a/jobs/consul_agent/spec
+++ b/jobs/consul_agent/spec
@@ -63,6 +63,10 @@ properties:
   consul.agent.node_name:
     description: "Node name for the agent. (Defaults to the BOSH instance group name)"
 
+  consul.agent.node_name_includes_id:
+    description: "whether to include the unique spec.id in the node name"
+    default: false
+
   consul.agent.mode:
     description: "Mode to run the agent in. (client or server)"
     default: client

--- a/jobs/consul_agent/templates/confab.json.erb
+++ b/jobs/consul_agent/templates/confab.json.erb
@@ -17,6 +17,14 @@
   network.ip
   end
 
+  def consul
+    config = p('consul')
+    if config['agent']['node_name_includes_id']
+      config['agent']['node_name'] = "#{spec.name}-#{spec.id}"
+    end
+    config
+  end
+
   {
     node: {
       name: name,
@@ -24,6 +32,6 @@
       external_ip: discover_external_ip,
       zone: spec.az,
     },
-    consul: p('consul'),
+    consul: consul,
   }.to_json
 %>

--- a/jobs/consul_agent_windows/templates/confab.json.erb
+++ b/jobs/consul_agent_windows/templates/confab.json.erb
@@ -20,6 +20,9 @@
   def consul
     config = p('consul')
     config["agent"]["mode"] = 'client'
+    if config['agent']['node_name_includes_id']
+      config['agent']['node_name'] = "#{spec.name}-#{spec.id}"
+    end
     config
   end
 


### PR DESCRIPTION
- use bosh spec.id when node_name_includes_id is set to true for the
consul agent

Signed-off-by: Chris Piraino <cpiraino@pivotal.io>