### PR TITLE
Add node_name_includes_id to consul_agent_windows spec file

### DIFF
--- a/jobs/consul_agent_windows/spec
+++ b/jobs/consul_agent_windows/spec
@@ -26,6 +26,10 @@ consumes:
   optional: true
 
 properties:
+  consul.agent.node_name_includes_id:
+    description: "whether to include the unique spec.id in the node name"
+    default: false
+
   consul.agent.servers.lan:
     description: "LAN server addresses to join on start."
     default: []


### PR DESCRIPTION
We missed adding the config in the windows spec file in https://github.com/cloudfoundry-incubator/consul-release/pull/75

[#150431952]

Signed-off-by: Caroline Taymor <ctaymor@pivotal.io>