### PR TITLE
IDN encode zone tag for AZ affinity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "src/acceptance-tests/testing/fake-dns-server/vendor/github.com/miekg/dns"]
 	path = src/acceptance-tests/testing/fake-dns-server/vendor/github.com/miekg/dns
 	url = https://github.com/miekg/dns.git
+[submodule "src/confab/vendor/golang.org/x/net"]
+	path = src/confab/vendor/golang.org/x/net
+	url = https://go.googlesource.com/net

--- a/src/confab/chaperon/controller.go
+++ b/src/confab/chaperon/controller.go
@@ -39,7 +39,7 @@ type agentClient interface {
 }
 
 type serviceDefiner interface {
-	GenerateDefinitions(config.Config) []config.ServiceDefinition
+	GenerateDefinitions(config.Config) ([]config.ServiceDefinition, error)
 	WriteDefinitions(string, []config.ServiceDefinition) error
 }
 
@@ -170,7 +170,10 @@ func (c Controller) StopAgent() {
 
 func (c Controller) WriteServiceDefinitions() error {
 	c.Logger.Info("controller.write-service-definitions.generate-definitions")
-	definitions := c.ServiceDefiner.GenerateDefinitions(c.Config)
+	definitions, err := c.ServiceDefiner.GenerateDefinitions(c.Config)
+	if err != nil {
+		return err
+	}
 
 	c.Logger.Info("controller.write-service-definitions.write")
 	if err := c.ServiceDefiner.WriteDefinitions(c.ConfigDir, definitions); err != nil {

--- a/src/confab/fakes/service_definer.go
+++ b/src/confab/fakes/service_definer.go
@@ -9,6 +9,7 @@ type ServiceDefiner struct {
 		}
 		Returns struct {
 			Definitions []config.ServiceDefinition
+			Error       error
 		}
 	}
 
@@ -29,7 +30,7 @@ func (d *ServiceDefiner) WriteDefinitions(configDir string, definitions []config
 	return d.WriteDefinitionsCall.Returns.Error
 }
 
-func (d *ServiceDefiner) GenerateDefinitions(config config.Config) []config.ServiceDefinition {
+func (d *ServiceDefiner) GenerateDefinitions(config config.Config) ([]config.ServiceDefinition, error) {
 	d.GenerateDefinitionsCall.Receives.Config = config
-	return d.GenerateDefinitionsCall.Returns.Definitions
+	return d.GenerateDefinitionsCall.Returns.Definitions, d.GenerateDefinitionsCall.Returns.Error
 }


### PR DESCRIPTION
- added conversion of '@' to '-'
- this is to maintain AZ affinity for any zone name with special characters