### PR TITLE
Set priority of consul agent to 'High'

### DIFF
--- a/jobs/consul_agent_windows/spec
+++ b/jobs/consul_agent_windows/spec
@@ -7,6 +7,7 @@ templates:
   confab.json.erb: confab.json
   consul_link.json.erb: consul_link.json
   pre-start.ps1.erb: bin/pre-start.ps1
+  post-start.ps1.erb: bin/post-start.ps1
 
 packages:
 - consul-windows

--- a/jobs/consul_agent_windows/templates/post-start.ps1.erb
+++ b/jobs/consul_agent_windows/templates/post-start.ps1.erb
@@ -1,0 +1,6 @@
+﻿$ErrorActionPreference = "Stop";
+trap {
+  $host.SetShouldExit(1)
+}
+
+(Get-Process -Name consul).PriorityClass='High'


### PR DESCRIPTION
If the CPU is under load (99-100%) DNS lookups for internal CF
components (through consul) will time out. By raising the priority of the
consul process, we can ensure that it is never starved of CPU,
preventing the timeouts